### PR TITLE
Fix IVL_TS -> IVL-TS type in Material expiration time

### DIFF
--- a/input/resources/Material.xml
+++ b/input/resources/Material.xml
@@ -115,7 +115,7 @@
       <min value="0"/>
       <max value="1"/>
       <type>
-        <code value="http://hl7.org/cda/stds/core/StructureDefinition/IVL_TS"/>
+        <code value="http://hl7.org/cda/stds/core/StructureDefinition/IVL-TS"/>
       </type>
     </element>
   </differential>


### PR DESCRIPTION
Hello!

While working on a [Atomic EHR code generator](https://github.com/atomic-ehr/codegen) I was getting an error about `IVL_TS` type being unknown in `Material`. So I went and checked, and the type seems to be malformed. The right type name is `IVL-TS`, as used everywhere else. Thus this PR.